### PR TITLE
19 - fix executable .jar file (#26)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.epam.prejap</groupId>
     <artifactId>tetris</artifactId>
-    <version>0.3</version>
+    <version>0.4</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -29,7 +29,9 @@
         </dependency>
     </dependencies>
 
+
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -39,10 +41,39 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
-                            <mainClass>com.epam.prejap.sdp.git.tetris.Tetris</mainClass>
+                            <mainClass>com.epam.prejap.tetris.Tetris</mainClass>
                         </manifest>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <argLine>-DoutputPath=${project.build.directory}/${project.build.finalName}.jar</argLine>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/integration_testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/epam/prejap/tetris/JarFileTest.java
+++ b/src/test/java/com/epam/prejap/tetris/JarFileTest.java
@@ -1,0 +1,54 @@
+package com.epam.prejap.tetris;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+@Test(groups = "JarFile")
+public class JarFileTest {
+
+    private static final String expectedMainClassName = Tetris.class.getCanonicalName();
+
+    @Test(dataProvider = "manifestForCheckingJar", dependsOnMethods = "dataProviderTest")
+    public void shallContainsSameMainClassName(Manifest manifest) {
+        //given
+        Attributes mainAttributes = manifest.getMainAttributes();
+
+        //when
+        String actualJarMainClassName = mainAttributes.getValue("Main-Class");
+
+        //then
+        assertEquals(actualJarMainClassName, expectedMainClassName,
+                String.format("Manifest file shall contains %s as main class name, but did not",
+                        expectedMainClassName));
+    }
+
+    @DataProvider
+    public static Object[][] manifestForCheckingJar() {
+        String outputPathProperty = System.getProperty("outputPath");
+        Path outputPath = Path.of(outputPathProperty);
+
+        Manifest manifest = null;
+        try {
+            JarFile jarFile = new JarFile(outputPath.toString());
+            manifest = jarFile.getManifest();
+        } catch (IOException e) {
+            fail(".jar or MANIFEST.MF file does not exist");
+        }
+        return new Object[][]{{manifest}};
+    }
+
+    @Test
+    public void dataProviderTest() {
+        manifestForCheckingJar();
+    }
+
+}

--- a/src/test/resources/integration_testng.xml
+++ b/src/test/resources/integration_testng.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+
+<!-- *************************************************************** -->
+<!-- This file is required                                           -->
+<!-- *************************************************************** -->
+
+<suite name="TetrisIntegrationSuite" time-out="10000" verbose="1">
+    <test name="IntegrationTests">
+        <groups>
+            <run>
+                <include name="JarFile"/>
+            </run>
+        </groups>
+        <classes>
+            <class name="com.epam.prejap.tetris.JarFileTest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
* Change mainClass package path to fix problem with running .jar file

* Change pom.xml

Add execution tag in maven-jar-plugin to execute package phase before test phase

* Add JarFileTest class, change testng.xml

Test pass when Manifest file in .jar contains Tetris class as main class

* Add new line at EOF

* Change execution phase of maven-jar-plugin

* Add finalName tag to pom.xml

* Add integration_testng.xml with integration test suite

* Change implementation of JarFileTest class
Add dataProviderTest to check if @DataProvider manifestForCheckingJar doesn't throws exception; in case of exception, test failures and target test is skipped

* Update pom.xml
Change finalName to project.artifactId
Add maven-surefire-plugin with testng.xml as suiteXmlFile
Add maven-failsafe-plugin with integration_testng.xml as suiteXmlFile

* Add integration-test and verify goals to maven-failsafe-plugin

* Bump up version in pom.xml

* Change path of .jar from fixed value to value from system properties
Add argLine tag in maven-failsafe-plugin to create outputPath variable that is passed as JVM arg
Retrieve outputPath variable by System.getProperty from JVM args in JarFileTest