### PR TITLE
2-add J shaped block (#23)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,32 +3,38 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>com.epam.prejap</groupId>
     <artifactId>tetris</artifactId>
-    <version>0.4</version>
+    <version>0.5</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>14</maven.compiler.source>
-        <maven.compiler.target>14</maven.compiler.target>
+        <project.java.version>14</project.java.version>
+        <maven.compiler.source>${project.java.version}</maven.compiler.source>
+        <maven.compiler.target>${project.java.version}</maven.compiler.target>
+        <!-- plugin versions should go here, so below they can be omitted -->
+        <version.plugin.maven.jar>3.2.0</version.plugin.maven.jar>
+        <version.plugin.maven.surefire>3.0.0-M5</version.plugin.maven.surefire>
+        <version.plugin.maven.failsafe>3.0.0-M5</version.plugin.maven.failsafe>
+        <!-- dependencies versions -->
+        <version.testng>7.3.0</version.testng>
+        <version.mockito>1.10.19</version.mockito>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.3.0</version>
+            <version>${version.testng}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
     <build>
         <finalName>${project.artifactId}</finalName>
@@ -36,7 +42,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>${version.plugin.maven.jar}</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -49,7 +55,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>${version.plugin.maven.surefire}</version>
                 <configuration>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
@@ -59,7 +65,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>${version.plugin.maven.failsafe}</version>
                 <configuration>
                     <argLine>-DoutputPath=${project.build.directory}/${project.build.finalName}.jar</argLine>
                     <suiteXmlFiles>

--- a/src/main/java/com/epam/prejap/tetris/block/BlockFeed.java
+++ b/src/main/java/com/epam/prejap/tetris/block/BlockFeed.java
@@ -8,7 +8,7 @@ public class BlockFeed {
 
     private final Random rnd = new Random();
     private final List<Supplier<Block>> blocks = List.of(
-        OBlock::new, LBlock::new, IBlock::new
+        OBlock::new, LBlock::new, IBlock::new, JBlock::new
     );
 
     public BlockFeed() {

--- a/src/main/java/com/epam/prejap/tetris/block/JBlock.java
+++ b/src/main/java/com/epam/prejap/tetris/block/JBlock.java
@@ -1,0 +1,22 @@
+package com.epam.prejap.tetris.block;
+
+/**
+ * J-shaped block implementation of the {@link Block} abstract class.
+ * <br>
+ *
+ * @author Łukasz Bulczak
+ * @implNote This class implements static 2d array in order to create required "J" shape block.
+ * @see Block
+ */
+final class JBlock extends Block {
+
+    private static final byte[][] IMAGE = {
+            {0, 1},
+            {0, 1},
+            {1, 1},
+    };
+
+    JBlock() {
+        super(IMAGE);
+    }
+}

--- a/src/main/java/com/epam/prejap/tetris/block/OBlock.java
+++ b/src/main/java/com/epam/prejap/tetris/block/OBlock.java
@@ -1,5 +1,13 @@
 package com.epam.prejap.tetris.block;
 
+/**
+ * O-shaped block implementation of the {@link Block} abstract class.
+ * <br>
+ *
+ * @author Pawel Kierat
+ * @implNote This class implements static 2d array in order to create required "O" shape block.
+ * @see Block
+ */
 final class OBlock extends Block {
 
     private static final byte[][] IMAGE = {

--- a/src/test/java/com/epam/prejap/tetris/block/BlockFeedTest.java
+++ b/src/test/java/com/epam/prejap/tetris/block/BlockFeedTest.java
@@ -2,18 +2,21 @@ package com.epam.prejap.tetris.block;
 
 import org.testng.annotations.Test;
 
-import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 @Test(groups = "Block")
 public class BlockFeedTest {
 
+    private final Class<? extends Block> blockChildClass;
+
+    public BlockFeedTest(Class<? extends Block> blockChildClass) {
+        this.blockChildClass = blockChildClass;
+    }
+
     @Test
-    public void shallContainLBlock() {
+    public void shallContainSpecificBlock() {
         //given
         BlockFeed feed = new BlockFeed();
 
@@ -21,53 +24,25 @@ public class BlockFeedTest {
         boolean containsLBlock = feed.blocks()
                 .stream()
                 .map(Supplier::get)
-                .anyMatch(e -> e instanceof LBlock);
+                .anyMatch(blockChildClass::isInstance);
 
         //then
         assertTrue(containsLBlock);
     }
 
-    @Test(dependsOnMethods = "shallContainLBlock")
-    public void shallContainOnlyOneLBlock() {
+    @Test(dependsOnMethods = "shallContainSpecificBlock")
+    public void shallContainOnlyOneBlockOfThatType() {
         //given
         BlockFeed feed = new BlockFeed();
 
         //when
-        List<Block> blocks = feed.blocks()
+        var numOfBlocks = feed.blocks()
                 .stream()
                 .map(Supplier::get)
-                .filter(e -> e instanceof LBlock)
-                .collect(Collectors.toList());
-
-        //then
-        assertEquals(blocks.size(), 1);
-    }
-
-    public void shallContainIBlock() {
-        //given
-        List<Supplier<Block>> feedList = new BlockFeed().blocks();
-
-        //when
-        boolean containsLBlock = feedList.stream()
-                .map(Supplier::get)
-                .anyMatch(e -> e instanceof LBlock);
-
-        //then
-        assertTrue(containsLBlock);
-    }
-
-    public void shallContainOnlyOneIBlock() {
-        //given
-        List<Supplier<Block>> feedList = new BlockFeed().blocks();
-
-        //when
-        long actual = feedList.stream()
-                .map(Supplier::get)
-                .filter(block -> block instanceof IBlock)
+                .filter(blockChildClass::isInstance)
                 .count();
 
         //then
-        assertEquals(actual, 1);
+        assertEquals(numOfBlocks, 1);
     }
-
 }

--- a/src/test/java/com/epam/prejap/tetris/block/BlockFeedTestFactory.java
+++ b/src/test/java/com/epam/prejap/tetris/block/BlockFeedTestFactory.java
@@ -1,0 +1,31 @@
+package com.epam.prejap.tetris.block;
+
+import org.testng.annotations.Factory;
+
+/**
+ *  Performing the same tests for each new block causes code duplication. To avoid this, a method has been created
+ *  that supplies {@link BlockFeedTest} class with concrete types of a {@link Block} class.
+ * <p>
+ * Thanks to this structure, each test from the BlockFeedTest class will be performed for each type provided
+ * by the {@link #factoryMethod()} below.
+ * </p><p>
+ * Adding tests for a new type of Block requires adding a new type in the method below.
+ * </p><p>
+ * Sample implementation:<br>
+ * <pre>{@code new BlockFeedTest(<NEW_BLOCK_CLASS_NAME>.class) }</pre>
+ *
+ * @author Łukasz Bulczak
+ * @see Block
+ * @see BlockFeedTest
+ */
+public class BlockFeedTestFactory {
+    @Factory
+    public Object[] factoryMethod() {
+        return new Object[]{
+                new BlockFeedTest(LBlock.class),
+                new BlockFeedTest(OBlock.class),
+                new BlockFeedTest(JBlock.class),
+                new BlockFeedTest(IBlock.class),
+        };
+    }
+}

--- a/src/test/java/com/epam/prejap/tetris/block/JBlockTest.java
+++ b/src/test/java/com/epam/prejap/tetris/block/JBlockTest.java
@@ -1,0 +1,77 @@
+package com.epam.prejap.tetris.block;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+import static org.testng.Assert.*;
+
+@Test(groups = "Block")
+public class JBlockTest {
+    @Test
+    public void shallCreateJBlockWithCorrectDimensions() {
+        //given
+        SoftAssert softAssert = new SoftAssert();
+        Block jBlock = new JBlock();
+        byte[][] expectedImage = new byte[3][2];
+
+        //when
+        int actualRows = jBlock.rows;
+        int actualCols = jBlock.cols;
+
+        //then
+        softAssert.assertEquals(actualRows, expectedImage.length,
+                String.format("The expected height for a J-shaped block should be %d, but was %d.",
+                        expectedImage.length, actualRows));
+
+        softAssert.assertEquals(actualCols, expectedImage[0].length,
+                String.format("The expected width for a J-shaped block should be %d, but was %d.",
+                        expectedImage[0].length, actualCols));
+
+        softAssert.assertAll("Shall create J block with correct dimensions, but did not");
+    }
+
+    @Test(dataProvider = "dotsForJBlock")
+    public void shallCreateJBlockWithJShapedDots(int row, int col) {
+        //given
+        Block jBlock = new JBlock();
+        int dotMark = 1;
+
+        //when
+        byte actualDot = jBlock.dotAt(row, col);
+
+        //then
+        assertEquals(actualDot, dotMark, "Shall create J block with correct shaped dots, but did not");
+    }
+
+    @Test(dataProvider = "emptySpacesForJBlock")
+    public void shallCreateJBlockWithCorrectEmptySpaces(int row, int col) {
+        //given
+        Block jBlock = new JBlock();
+        int emptyMark = 0;
+
+        //when
+        byte actualEmptySpace = jBlock.dotAt(row, col);
+
+        //then
+        assertEquals(actualEmptySpace, emptyMark, "Shall create J block with correct shaped empty marks, but did not");
+    }
+
+    @DataProvider()
+    public static Object[] dotsForJBlock() {
+        return new Object[][]{
+                {0, 1},
+                {1, 1},
+                {2, 0},
+                {2, 1},
+        };
+    }
+
+    @DataProvider()
+    public static Object[] emptySpacesForJBlock() {
+        return new Object[][]{
+                {0, 0},
+                {1, 0},
+        };
+    }
+}

--- a/src/test/java/com/epam/prejap/tetris/block/OBlockTest.java
+++ b/src/test/java/com/epam/prejap/tetris/block/OBlockTest.java
@@ -1,0 +1,57 @@
+package com.epam.prejap.tetris.block;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+import static org.testng.Assert.*;
+
+@Test(groups = "Block")
+public class OBlockTest {
+
+    @Test
+    public void shallCreateOBlockWithCorrectDimensions() {
+        //given
+        SoftAssert softAssert = new SoftAssert();
+        Block oBlock = new OBlock();
+        byte[][] expectedImage = new byte[2][2];
+
+        //when
+        int actualRows = oBlock.rows;
+        int actualCols = oBlock.cols;
+
+        //then
+        softAssert.assertEquals(actualRows, expectedImage.length,
+                String.format("The expected height for a O-shaped block should be %d, but was %d.",
+                        expectedImage.length, actualRows));
+
+        softAssert.assertEquals(actualCols, expectedImage[0].length,
+                String.format("The expected width for a O-shaped block should be %d, but was %d.",
+                        expectedImage[0].length, actualCols));
+
+        softAssert.assertAll("Shall create O block with correct dimensions, but did not");
+    }
+
+    @Test(dataProvider = "dotsForOBlock")
+    public void shallCreateOBlockWithOShapedDots(int row, int col) {
+        //given
+        Block oBlock = new OBlock();
+        int dotMark = 1;
+
+        //when
+        byte actualDot = oBlock.dotAt(row, col);
+
+        //then
+        assertEquals(actualDot, dotMark, "Shall create O block with correct shaped dots, but did not");
+    }
+
+    @DataProvider()
+    public static Object[] dotsForOBlock() {
+        return new Object[][]{
+                {0, 0},
+                {0, 1},
+                {1, 0},
+                {1, 1},
+        };
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -14,8 +14,11 @@
             </run>
         </groups>
         <classes>
+            <class name="com.epam.prejap.tetris.block.OBlockTest"/>
+            <class name="com.epam.prejap.tetris.block.JBlockTest"/>
             <class name="com.epam.prejap.tetris.block.LBlockTest"/>
-            <class name="com.epam.prejap.tetris.block.BlockFeedTest"/>
+            <class name="com.epam.prejap.tetris.block.IBlockTest"/>
+            <class name="com.epam.prejap.tetris.block.BlockFeedTestFactory"/>
             <class name="com.epam.prejap.tetris.player.RandomPlayerTest"/>
             <class name="com.epam.prejap.tetris.game.PrinterTest"/>
             <class name="com.epam.prejap.tetris.game.TimerTest"/>


### PR DESCRIPTION
* Create a new class to represent the "J" shaped block

* Reimplement constructor to match convention

* Write JavaDoc for JBlock class

* Create class JBlockTest

* Test creation of JBlock

* Test correct creation of JBlock (proper marks position)

* Test correct creation of JBlock (proper empty marks position)

* Add new type of block to BlockFeed

* Delete JavaDoc for parts which are not a part of public API

* Add new line character at EOF

* Add missing tests to BlockFeed

* Refactor generalize BlockFeedTest

* Remove unnecessary tags in javadoc

* Add an explanatory description for BlockFeedTestFactory

* Add proper tests conditions and messages

* Do not reinvent the wheel - X::isInstance

Comparing classes based on their names is not the best solution.
For a broader explanation of this problem,
see https://wiki.sei.cmu.edu/confluence/display/java/OBJ09-J.+Compare+classes+and+not+class+names

* Rename the test methods

* Change the JavaDoc to describe current implementation

* Bump up the minor version number

* Changes in pom.xml

* Inform Maven about testng.xml

* Fix problem from merging

One of the lines should not be removed but was.

* Add IBlock to BlockFeedTestFactory

* Add IBlock to testng.xml

* Add new test class - OBlockTest

* Testing proper dimensions of OBlock

* Testing proper shape of OBlock

* Change in JavaDoc describing the class

* Change in JavaDoc describing the class

* Change typo in JavaDoc describing the class

* Fix the project coordinates order

* Fix arguments order - the new one  as last

* Add EOF

* Fix wrong path to mainClass